### PR TITLE
Budget app: Add x86_64-linux platform to the lock file

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -137,11 +137,14 @@ GEM
     nio4r (2.5.9)
     nokogiri (1.15.4-x64-mingw-ucrt)
       racc (~> 1.4)
+    nokogiri (1.15.4-x86_64-linux)
+      racc (~> 1.4)
     orm_adapter (0.5.0)
     parallel (1.23.0)
     parser (3.2.2.3)
       ast (~> 2.4.1)
       racc
+    pg (1.5.4)
     pg (1.5.4-x64-mingw-ucrt)
     public_suffix (5.0.3)
     puma (5.6.7)
@@ -265,6 +268,7 @@ GEM
 
 PLATFORMS
   x64-mingw-ucrt
+  x86_64-linux
 
 DEPENDENCIES
   bootsnap


### PR DESCRIPTION
Add x86_64-linux platform to the lock file to solve deployment issues.